### PR TITLE
Height must take into account padding

### DIFF
--- a/inobounce.js
+++ b/inobounce.js
@@ -24,7 +24,9 @@
 
 			var scrolling = style.getPropertyValue('-webkit-overflow-scrolling');
 			var overflowY = style.getPropertyValue('overflow-y');
-			var height = parseInt(style.getPropertyValue('height'), 10);
+			var paddingTop = parseInt(style.getPropertyValue('padding-top'), 10);
+			var paddingBot = parseInt(style.getPropertyValue('padding-bottom'), 10);
+			var height = paddingTop+paddingBot+parseInt(style.getPropertyValue('height'), 10);
 
 			// Determine if the element should scroll
 			var isScrollable = scrolling === 'touch' && (overflowY === 'auto' || overflowY === 'scroll');


### PR DESCRIPTION
To check if element is at bottom, the element height must take into account margin-top and margin-bottom. Otherwise it doesn't work if element has padding (not sure about margins)
